### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/public/assets/css/new.css
+++ b/public/assets/css/new.css
@@ -201,6 +201,10 @@
   border-bottom: none;
 }
 
+.avatar-wrapper {
+  margin-left: 10px;
+}
+
 /* Columns */
 .avatar-column {
   margin-right: 16px;
@@ -426,6 +430,10 @@
 }
 
 @media (max-width: 768px) {
+  .coinflip-container {
+    padding: 24px;
+    gap: 24px;
+  }
   .coinflip-button-row {
     flex-direction: column;
     align-items: start;
@@ -445,6 +453,9 @@
 }
 
 @media (max-width: 480px) {
+  .coinflip-container {
+    padding: 16px;
+  }
   .choice-buttons {
     flex-direction: column;
   }

--- a/public/assets/css/responsive.css
+++ b/public/assets/css/responsive.css
@@ -285,7 +285,43 @@
   }
 
   .header .mainmenu-area .navbar {
-    padding: 8px 0px;
+    padding: 8px 15px;
+    height: auto;
+  }
+
+  .header .mainmenu-area .navbar .navbar-brand img {
+    height: 50px;
+  }
+
+  .header .mainmenu-area .navbar #main_menu {
+    background: rgba(7, 11, 40, 0.95);
+    border-radius: 12px;
+    padding: 16px;
+    margin-top: 10px;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header .mainmenu-area .navbar #main_menu .navbar-nav {
+    flex-direction: column;
+    width: 100%;
+    margin-bottom: 12px;
+  }
+
+  .header .mainmenu-area .navbar #main_menu .navbar-nav .nav-item {
+    text-align: center;
+  }
+
+  .header .mainmenu-area .navbar #main_menu w3m-button {
+    width: 100%;
+    margin-left: 0;
+    display: block;
+  }
+
+  .header .mainmenu-area .navbar #main_menu .avatar-wrapper {
+    margin-left: 0;
+    width: 100%;
+    justify-content: center;
   }
 
   .hero-area {
@@ -808,6 +844,13 @@
     margin-left: 0px;
     padding: 30px;
   }
+  .prize-pools.coinflip .mega-prize-pool .right .r-row {
+    align-items: center;
+  }
+  .prize-pools.coinflip .mega-prize-pool .right .r-row .d-flex {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
   .timer-box .content {
     flex-direction: column;
     justify-content: center;
@@ -1030,6 +1073,13 @@
 
 
 @media (max-width: 575px) {
+  .prize-pools .mega-prize-pool .right {
+    padding: 20px;
+    border-radius: 32px;
+  }
+  .prize-pools .mega-prize-pool .right .r-row {
+    align-items: center;
+  }
   .hero-area {
     padding: 232px 0px 265px;
   }

--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -194,7 +194,7 @@ export default function Avatar() {
 
   return (
     <>
-      <div style={{ display: 'flex', alignItems: 'center', position: 'relative', marginLeft: 10 }}>
+      <div className="avatar-wrapper" style={{ display: 'flex', alignItems: 'center', position: 'relative' }}>
         <div className="avatar-column">
           <button
             type="button"

--- a/src/components/SocketLeaderboard.jsx
+++ b/src/components/SocketLeaderboard.jsx
@@ -7,6 +7,7 @@ function SocketLeaderboard({apiUrl, body}) {
   useSocketLeaderboard(apiUrl, body/*{ gameType: true, page: 1, limit: 10 }*/);
 
   if (loading) return <p>Loading leaderboard...</p>;
+  if (error) return <p>{error}</p>;
   
   return (
     

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -22,8 +22,12 @@ const TopBar = () => {
                       aria-label="Toggle navigation">
                       <span className="navbar-toggler-icon"></span>
                     </button>
-                    <div className="collapse navbar-collapse justify-content-end fixed-height" id="main_menu" style={{marginRight: "24px"}}>
-                      <ul className="navbar-nav ml-auto">
+                    <div
+                      className="collapse navbar-collapse flex-column flex-lg-row align-items-start align-items-lg-center"
+                      id="main_menu"
+                      style={{ marginRight: "24px" }}
+                    >
+                      <ul className="navbar-nav mb-3 mb-lg-0 me-lg-auto">
                         {
                           menuConfig.map((item, index) => {
                             return (
@@ -36,8 +40,10 @@ const TopBar = () => {
                         }
 
                       </ul>
-                      <w3m-button />
-                      <Avatar />
+                      <div className="d-flex flex-column flex-lg-row align-items-start align-items-lg-center gap-2 w-100 w-lg-auto">
+                        <w3m-button />
+                        <Avatar />
+                      </div>
                     </div>
                   </div>
                 </nav>

--- a/src/components/useSocketLeaderboard.jsx
+++ b/src/components/useSocketLeaderboard.jsx
@@ -18,7 +18,7 @@ export default function useSocketLeaderboard(
   body = { gameType: '', page: 1, limit: 10 }
 ) {
   // console.log("useSocketLeaderboard", path, body);
-  const [leaderboard, setLeaderboard] = useState(null);
+  const [leaderboard, setLeaderboard] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -51,6 +51,7 @@ export default function useSocketLeaderboard(
       } catch (e) {
         if (e.name !== "AbortError") {
           setError(e.message || "Failed to load leaderboard");
+          setLeaderboard([]);
         }
       } finally {
         setLoading(false);

--- a/src/container/CoinFlip.jsx
+++ b/src/container/CoinFlip.jsx
@@ -445,8 +445,8 @@ function CoinFlip() {
                       <p>50/50 chance to win big – pick a side and flip the coin!</p>
                     </div>
                   </div>
-                  <div className='r-row mt-3'>
-                    <div className='d-flex'>
+                    <div className='r-row mt-3'>
+                      <div className='d-flex flex-wrap justify-content-center'>
                       <div className='item'>
                         <div className={isHead ? "count active" : "count"} onClick={() => setIsHead(true)}>
                           <img src="/assets/images/game/head.png" alt="" width={40} />
@@ -461,10 +461,10 @@ function CoinFlip() {
                       </div>
                     </div>
                   </div>
-                  <div className='r-row mt-3'>
-                    <div className='d-flex' style={{flexDirection: 'column'}}>
-                        <span>WAGER:</span>
-                      <div className='d-flex'>
+                    <div className='r-row mt-3'>
+                      <div className='d-flex flex-column align-items-center'>
+                          <span>WAGER:</span>
+                        <div className='d-flex flex-wrap justify-content-center'>
                         {gameMinTokenAmount.map((value, idx) => (
                           <div className={idx === 0 ? 'item ml-0' : 'item ml-2'} key={value}>
                             <div


### PR DESCRIPTION
## Summary
- center coin flip controls on small screens and allow buttons to wrap
- tweak prize pool layout padding and alignment for better mobile experience
- add mobile-friendly padding for coin flip container
- prevent leaderboard crash when API request fails and surface error message
- clean up mobile header menu layout and make wallet controls stack neatly
- restore right-aligned wallet controls on desktop navigation

## Testing
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b369e375c0832e810eb66e4dac794f